### PR TITLE
Adding empty log and temp folders to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-temp
-log
 vendor
 .idea
 docker-compose.override.yml

--- a/log/.gitignore
+++ b/log/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/temp/.gitignore
+++ b/temp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Both folders are necessary for application to run correctly
and it wasn't obvious that they need to be created.
Having them present as empty folder seems better for
users of the tool.